### PR TITLE
Remove `noarch: python`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -708,7 +708,7 @@ outputs:
       - bin/diagd
     test:
       commands:
-        - test -x ${PREFIX}/bin/diagd # [unix]
+        - test -x ${PREFIX}/bin/diagd  # [unix]
     about:
       home: https://git.ligo.org/cds/dtt
       dev_url: https://git.ligo.org/cds/dtt.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - rpcgen-cpp-path.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
@@ -450,8 +450,6 @@ outputs:
 
   - name: python-foton
     script: build-python-foton.sh
-    build:
-      noarch: python
     requirements:
       build:
         - cmake
@@ -489,8 +487,6 @@ outputs:
 
   - name: python-awg
     script: build-python-awg.sh
-    build:
-      noarch: python
     requirements:
       build:
         - cmake
@@ -998,8 +994,6 @@ outputs:
   # -- metapackage ----------
 
   - name: cds-crtools
-    build:
-      noarch: python
     requirements:
       host:
         - nds2-client


### PR DESCRIPTION
This PR removes the `noarch: python` for the python packages, so that multiple pinned library builds result in multiple python packages. The current situation of multiple root_base pins end up with some python packages not being updated because the `noarch: python` result in a non-unique package hash.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
