### PR TITLE
Recipe cleanup

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,6 +18,10 @@ expat:
 - '2'
 fftw:
 - '3'
+numpy:
+- '1.21'
+- '1.21'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -35,3 +39,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,6 +18,14 @@ expat:
 - '2'
 fftw:
 - '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 root_base:
@@ -27,5 +35,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zstd:
-- '1.5'

--- a/.ci_support/migrations/root_base6280.yaml
+++ b/.ci_support/migrations/root_base6280.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1678010531.520769
+root_base:
+- 6.28.0

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,6 +18,10 @@ fftw:
 - '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+numpy:
+- '1.21'
+- '1.21'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -28,10 +32,12 @@ python:
 - 3.9.* *_cpython
 readline:
 - '8'
+root_base:
+- 6.28.0
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zstd:
-- '1.5'
+- - python
+  - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,6 +18,14 @@ fftw:
 - '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,6 +18,14 @@ fftw:
 - '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 readline:
 - '8'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,6 +18,10 @@ fftw:
 - '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
+numpy:
+- '1.21'
+- '1.21'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -28,10 +32,12 @@ python:
 - 3.9.* *_cpython
 readline:
 - '8'
+root_base:
+- 6.28.0
 target_platform:
 - osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-zstd:
-- '1.5'
+- - python
+  - numpy

--- a/README.md
+++ b/README.md
@@ -121,20 +121,6 @@ Development: https://git.ligo.org/cds/dtt.git
 
 DMT is part of the LIGO real-time data acquisition system
 
-About libfilterwiz
-------------------
-
-Home: https://git.ligo.org/cds/dtt
-
-Package license: GPL-2.0-or-later
-
-Summary: Functions for creating foton-style filter design windows.
-
-Development: https://git.ligo.org/cds/dtt.git
-
-Other LIGO programs such as `awggui` and `diaggui` use `libfilterwiz` to create
-`foton`-style filter design windows for one-off filters.
-
 About python-foton
 ------------------
 
@@ -313,21 +299,19 @@ Development: https://git.ligo.org/cds/dtt.git
 
 Includes xmlconv, xmldata, and xmldir.  Files can be produced by diag or diaggui.
 
-About foton
------------
+About libfilterwiz
+------------------
 
 Home: https://git.ligo.org/cds/dtt
 
 Package license: GPL-2.0-or-later
 
-Summary: Graphical program for designing and generating filters.
+Summary: Functions for creating foton-style filter design windows.
 
 Development: https://git.ligo.org/cds/dtt.git
 
-`foton` is used at LIGO to design and display filters,
-then generate filter files usable by the LIGO real-time
-data acquisition system.
-A variety of design strategies are supported.
+Other LIGO programs such as `awggui` and `diaggui` use `libfilterwiz` to create
+`foton`-style filter design windows for one-off filters.
 
 About lidax
 -----------
@@ -356,6 +340,22 @@ Development: https://git.ligo.org/cds/dtt.git
 Create excitations using LIGO\'s awgtpman using Python.
 The awg module allows simple python scripting of excitations
 on the LIGO data acquisition system.
+
+About foton
+-----------
+
+Home: https://git.ligo.org/cds/dtt
+
+Package license: GPL-2.0-or-later
+
+Summary: Graphical program for designing and generating filters.
+
+Development: https://git.ligo.org/cds/dtt.git
+
+`foton` is used at LIGO to design and display filters,
+then generate filter files usable by the LIGO real-time
+data acquisition system.
+A variety of design strategies are supported.
 
 About cds-crtools
 -----------------

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://git.ligo.org/cds/software/dtt/-/archive/{{ versiontag }}/{{ versiontag }}.tar.gz  
+  url: https://git.ligo.org/cds/software/dtt/-/archive/{{ versiontag }}/{{ versiontag }}.tar.gz
   sha256: 1483316cf39f2335d1c0144459e7cec35c09fa1bdff38907f0e39f0e16c00ba6
   patches:
 
@@ -27,7 +27,7 @@ requirements:
     - zstd  # [osx]
     - fftw
     #- root_base  # [not osx]
-    - gds-base    
+    - gds-base
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:
     - python >=3.8
@@ -45,7 +45,7 @@ requirements:
     - readline
     # - root_base  # [not osx]
     # - pybind11
-    - numpy >=1.20    
+    - numpy >=1.20
 
 
 outputs:
@@ -232,7 +232,7 @@ outputs:
         - gds-base
     files:
       - include/foton/Filter*.hh
-      - lib/libfilterfile.*so*      
+      - lib/libfilterfile.*so*
     test:
       commands:
         - test -f ${PREFIX}/lib/libfilterfile.so  # [unix]
@@ -447,7 +447,7 @@ outputs:
 
   # -- python libraries -----
 
-  - name: python-foton    
+  - name: python-foton
     script: build-python-foton.sh
     requirements:
       build:
@@ -459,22 +459,22 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
         - pybind11
         - fftw
-        - numpy >=1.20  # [osx]        
+        - numpy >=1.20  # [osx]
         - scipy  # [osx]
-        - gds-base        
+        - gds-base
         - cross-python_{{ target_platform }}  # [build_platform != target_platform]
       host:
-        - {{ pin_subpackage('libfilterfile', exact=True) }}        
+        - {{ pin_subpackage('libfilterfile', exact=True) }}
         - python >=3.8
-        - numpy >=1.20  # [osx]        
+        - numpy >=1.20  # [osx]
         - scipy  # [osx]
         - fftw
-        - gds-base        
+        - gds-base
       run:
         - {{ pin_subpackage('libfilterfile', exact=True) }}
         - gds-base
-        - numpy >=1.20         
-        - python >=3.8  
+        - numpy >=1.20
+        - python >=3.8
         - scipy
         - fftw
     test:
@@ -501,7 +501,7 @@ outputs:
   - name: python-awg
     script: build-python-awg.sh
     build:
-      skip: true  # [osx]    
+      skip: true  # [osx]
     requirements:
       build:
         - cmake
@@ -513,7 +513,7 @@ outputs:
       host:
         - nds2-client
         - python >=3.8
-        - root_base        
+        - root_base
         - gds-gui-crtools  # [not osx]
       run:
         - {{ pin_subpackage('libawg', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "cds-crtools" %}
-{% set version = "3.1.5.dev4" %}
-{% set versiontag = "3.1.5_dev4" %}
+{% set version = "3.1.5_dev4" %}
 
 package:
   name: {{ name|lower }}-split
-  version: {{ version }}
+  version: {{ version|replace('_', '.') }}
 
 source:
-  url: https://git.ligo.org/cds/software/dtt/-/archive/{{ versiontag }}/{{ versiontag }}.tar.gz
+  url: https://git.ligo.org/cds/software/dtt/-/archive/{{ version }}/{{ version }}.tar.gz
   sha256: 1483316cf39f2335d1c0144459e7cec35c09fa1bdff38907f0e39f0e16c00ba6
   patches:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   error_overlinking: true
   error_overdepending: true
   number: 1
-  skip: true  # [not linux and not osx]
+  skip: true  # [win]
 
 requirements:
   build:
@@ -25,14 +25,7 @@ requirements:
     - pkg-config  # [not win]
     - python >=3.8
     - sysroot_linux-64 2.17  # [linux64]
-    - zstd  # [osx]
-    - fftw
-    #- root_base  # [not osx]
-    - gds-base
-    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:
-    - python >=3.8
-    - zstd  # [osx]
     - cyrus-sasl
     - expat
     - fftw
@@ -44,10 +37,7 @@ requirements:
     - gds-root-extensions-crtools  # [not osx]
     - nds2-client  # [not osx]
     - readline
-    # - root_base  # [not osx]
-    # - pybind11
-    - numpy >=1.20
-
+    - root_base
 
 outputs:
   # -- C libraries ----------
@@ -460,6 +450,9 @@ outputs:
 
   - name: python-foton
     script: build-python-foton.sh
+    build:
+      ignore_run_exports:
+        - numpy
     requirements:
       build:
         - {{ compiler('c') }}
@@ -474,6 +467,7 @@ outputs:
       host:
         - gds-base
         - {{ pin_subpackage('libfilterfile', exact=True) }}
+        - pybind11
         - python
         - scipy
       run:
@@ -519,14 +513,15 @@ outputs:
         - cross-python_{{ target_platform }}  # [build_platform != target_platform]
         - python                              # [build_platform != target_platform]
       host:
+        - gds-gui-crtools
         - nds2-client
+        - pybind11
         - python
         - root_base
-        - gds-gui-crtools
       run:
         - {{ pin_subpackage('libawg', exact=True) }}
-        - {{ pin_subpackage('libtestpoint', exact=True) }}
         - {{ pin_subpackage('libsistr', exact=True) }}
+        - {{ pin_subpackage('libtestpoint', exact=True) }}
         - numpy >=1.20
         - python
         - root_base
@@ -1064,13 +1059,9 @@ outputs:
       skip: true  # [osx]
     requirements:
       host:
-        #- nds2-client
-        #- python >=3.8
-        #- root_base
+        - python
       run:
-        #- nds2-client
-        #- python >=3.8
-        #- root_base
+        - python
         # all of the outputs
         - {{ pin_subpackage('chndump', exact=True) }}
         - {{ pin_subpackage('dmtviewer', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,6 @@ outputs:
       host:
         - gds-base
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - gds-base
         - {{ pin_subpackage('libtestpoint', exact=True) }}
@@ -104,7 +103,6 @@ outputs:
         - gds-base
         - {{ pin_subpackage('libfantom', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - gds-base
         - {{ pin_subpackage('libfantom', exact=True) }}
@@ -157,11 +155,11 @@ outputs:
         - nds2-client
         - readline
       run:
-        - expat
         - gds-base
         - gds-base-crtools
         - {{ pin_subpackage('libawg', exact=True) }}
         - {{ pin_subpackage('libdfm', exact=True) }}
+        - libexpat
         - {{ pin_subpackage('libfantom', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
         - nds2-client
@@ -198,7 +196,6 @@ outputs:
       host:
         - gds-base
         - gds-lsmp
-        - nds2-client
         - readline
       run:
         - gds-base
@@ -229,15 +226,9 @@ outputs:
         - {{ compiler('cxx') }}
         - make  # [unix]
         - sysroot_linux-64 2.17  # [linux64]
-        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
       host:
         - gds-base
-        - nds2-client
-        - zstd
-        - fftw
       run:
-        - fftw
-        - zstd
         - gds-base
     files:
       - include/foton/Filter*.hh
@@ -269,12 +260,17 @@ outputs:
         - make  # [not win]
         - sysroot_linux-64 2.17  # [linux64]
       host:
+        - crtools-gui-libraries
         - gds-base
+        - gds-gui-crtools
         - {{ pin_subpackage('libfilterfile', exact=True) }}
-        - nds2-client
+        - root_base
       run:
+        - crtools-gui-libraries
         - gds-base
+        - gds-gui-crtools
         - {{ pin_subpackage('libfilterfile', exact=True) }}
+        - root_base
     files:
       - include/foton/TLGFilter*.hh
       - lib/libfilterwiz{{ SHLIB_EXT }}*
@@ -308,7 +304,6 @@ outputs:
         - gds-base
         - {{ pin_subpackage('libawg', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - gds-base
         - {{ pin_subpackage('libawg', exact=True) }}
@@ -343,7 +338,6 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - gds-base
-        - nds2-client
       run:
         - gds-base
     files:
@@ -381,7 +375,6 @@ outputs:
         - gds-gui-crtools
         - {{ pin_subpackage('libdfm', exact=True) }}
         - {{ pin_subpackage('libfantom', exact=True) }}
-        - nds2-client
         - root_base
       run:
         - gds-base
@@ -435,8 +428,7 @@ outputs:
         - gds-base
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - {{ pin_subpackage('libfilterfile', exact=True) }}
-        - nds2-client
-        - root_base  # [osx]
+        - root_base
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - {{ pin_subpackage('libfilterfile', exact=True) }}
@@ -476,26 +468,20 @@ outputs:
         - make  # [unix]
         - pkg-config
         - sysroot_linux-64 2.17  # [linux64]
-        - pybind11
-        - fftw
-        - numpy >=1.20  # [osx]
-        - scipy  # [osx]
-        - gds-base
+        # extras for cross-compiling
         - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+        - python                              # [build_platform != target_platform]
       host:
-        - {{ pin_subpackage('libfilterfile', exact=True) }}
-        - python >=3.8
-        - numpy >=1.20  # [osx]
-        - scipy  # [osx]
-        - fftw
         - gds-base
-      run:
         - {{ pin_subpackage('libfilterfile', exact=True) }}
-        - gds-base
-        - numpy >=1.20
-        - python >=3.8
+        - python
         - scipy
-        - fftw
+      run:
+        - gds-base
+        - {{ pin_subpackage('libfilterfile', exact=True) }}
+        - numpy >=1.20
+        - python
+        - scipy
     test:
       source_files:
         - src/python/foton/
@@ -529,19 +515,20 @@ outputs:
         - make  # [unix]
         - pkg-config
         - sysroot_linux-64 2.17  # [linux64]
-        - gds-gui-crtools  # [not osx]
-        - pybind11
+        # extras for cross-compiling
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+        - python                              # [build_platform != target_platform]
       host:
         - nds2-client
-        - python >=3.8
+        - python
         - root_base
-        - gds-gui-crtools  # [not osx]
+        - gds-gui-crtools
       run:
         - {{ pin_subpackage('libawg', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
         - {{ pin_subpackage('libsistr', exact=True) }}
         - numpy >=1.20
-        - python >=3.8
+        - python
         - root_base
         - scipy
     test:
@@ -575,7 +562,6 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - {{ pin_subpackage('libdtt', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('libdtt', exact=True) }}
     files:
@@ -600,8 +586,7 @@ outputs:
         - gds-base
         - gds-base-crtools
         - gds-gui-crtools
-        - nds2-client
-        - root_base  # [osx]
+        - root_base
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - gds-base
@@ -636,14 +621,12 @@ outputs:
         - make  # [unix]
         - sysroot_linux-64 2.17  # [linux64]
       host:
-
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - gds-base
         - gds-gui-crtools
         - {{ pin_subpackage('libawg', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
-        - root_base  # [osx]
+        - root_base
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - gds-base
@@ -687,7 +670,6 @@ outputs:
         - {{ pin_subpackage('libdtt', exact=True) }}
         - {{ pin_subpackage('libsistr', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - gds-base
@@ -726,10 +708,8 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - {{ pin_subpackage('libdtt', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('libdtt', exact=True) }}
-        - nds2-client
     files:
       - bin/diag
     test:
@@ -760,7 +740,6 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - {{ pin_subpackage('libdtt', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('libdtt', exact=True) }}
     files:
@@ -870,7 +849,6 @@ outputs:
         - {{ pin_subpackage('libawg', exact=True) }}
         - {{ pin_subpackage('libdtt', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - gds-base
         - {{ pin_subpackage('libawg', exact=True) }}
@@ -906,7 +884,6 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('libtestpoint', exact=True) }}
     files:
@@ -940,7 +917,6 @@ outputs:
         - gds-base
         - {{ pin_subpackage('libdtt', exact=True) }}
         - {{ pin_subpackage('libtestpoint', exact=True) }}
-        - nds2-client
       run:
         - gds-base
         - {{ pin_subpackage('libdtt', exact=True) }}
@@ -978,7 +954,6 @@ outputs:
         - sysroot_linux-64 2.17  # [linux64]
       host:
         - {{ pin_subpackage('libfantom', exact=True) }}
-        - nds2-client
       run:
         - {{ pin_subpackage('libfantom', exact=True) }}
     files:
@@ -1013,7 +988,6 @@ outputs:
         - gds-base
         - {{ pin_subpackage('libfilterfile', exact=True) }}
         - {{ pin_subpackage('libfilterwiz', exact=True) }}
-        - nds2-client
         - root_base  # [osx]
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
@@ -1055,7 +1029,6 @@ outputs:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}
         - gds-base
         - {{ pin_subpackage('libdfm', exact=True) }}
-        - nds2-client
         - root_base  # [osx]
       run:
         - {{ pin_subpackage('crtools-gui-libraries', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   patches:
 
 build:
+  error_overlinking: true
+  error_overdepending: true
   number: 0
   skip: true  # [not linux and not osx]
 
@@ -52,6 +54,8 @@ outputs:
 
   - name: libawg
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -88,6 +92,8 @@ outputs:
 
   - name: libdfm
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -132,6 +138,8 @@ outputs:
 
   - name: libdtt
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -179,6 +187,8 @@ outputs:
 
   - name: libfantom
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -250,6 +260,8 @@ outputs:
 
   - name: libfilterwiz
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -284,6 +296,8 @@ outputs:
 
   - name: libsistr
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -319,6 +333,8 @@ outputs:
 
   - name: libtestpoint
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -351,6 +367,8 @@ outputs:
 
   - name: crtools-gui-libraries
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -405,6 +423,8 @@ outputs:
 
   - name: crtools-root-libraries
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -500,6 +520,8 @@ outputs:
   - name: python-awg
     script: build-python-awg.sh
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -543,6 +565,8 @@ outputs:
 
   - name: chndump
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -563,6 +587,8 @@ outputs:
 
   - name: dmtviewer
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -601,6 +627,8 @@ outputs:
 
   - name: dtt-awggui
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -644,6 +672,8 @@ outputs:
 
   - name: dtt-awgstream
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -686,6 +716,8 @@ outputs:
 
   - name: dtt-diag
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -718,6 +750,8 @@ outputs:
 
   - name: dtt-diagd
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -749,6 +783,8 @@ outputs:
 
   - name: dtt-diaggui
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -794,6 +830,8 @@ outputs:
 
   - name: dtt-monitors
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -819,6 +857,8 @@ outputs:
 
   - name: dtt-multiawgstream
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -856,6 +896,8 @@ outputs:
 
   - name: dtt-tpcmd
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -886,6 +928,8 @@ outputs:
 
   - name: dtt-xml-tools
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -924,6 +968,8 @@ outputs:
 
   - name: fantom
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -954,6 +1000,8 @@ outputs:
 
   - name: foton
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -995,6 +1043,8 @@ outputs:
 
   - name: lidax
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       build:
@@ -1036,6 +1086,8 @@ outputs:
 
   - name: cds-crtools
     build:
+      error_overlinking: true
+      error_overdepending: true
       skip: true  # [osx]
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   error_overlinking: true
   error_overdepending: true
-  number: 0
+  number: 1
   skip: true  # [not linux and not osx]
 
 requirements:


### PR DESCRIPTION
This PR cleans up a few things in the recipe

- remove all trailing whitespace
- simplify specifying version (only do it once)
- add `error_{overdepending,overlinking}` build flags to detect dependency issues
- remove all unused/overspecified dependencies
- add missing `root_base6280` migration file (closes #32)
- remove version specifiers for `python` (closes #31)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
