### PR TITLE
Reinstate python311 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,6 +20,7 @@ fftw:
 - '3'
 numpy:
 - '1.22'
+- '1.23'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -28,6 +29,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 readline:

--- a/.ci_support/migrations/python311.yaml
+++ b/.ci_support/migrations/python311.yaml
@@ -1,0 +1,37 @@
+migrator_ts: 1666686085
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 40
+    max_solver_attempts: 10  # this will make the bot retry "not solvable" stuff 10 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.11.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.23
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,6 +20,7 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
+- '1.23'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -28,6 +29,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 readline:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -20,6 +20,7 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
 - '1.22'
+- '1.23'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -28,6 +29,7 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 readline:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   error_overlinking: true
   error_overdepending: true
-  number: 4
+  number: 5
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
This PR reinstates the python311 migration that was removed by #60.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
